### PR TITLE
A few fixes to get Python 3 support working

### DIFF
--- a/stattlepy/Stattleship_API.py
+++ b/stattlepy/Stattleship_API.py
@@ -21,7 +21,7 @@ class Stattleship(object):
                 query = list()
                 version = 1
                 walk = False
-                page = None
+                page = 1
                 verbose = True
                 param = {}
                 
@@ -65,13 +65,13 @@ class Stattleship(object):
                 league = league.lower()
                 ep = ep.lower()        
                 
-                url = 'https://www.stattleship.com/%s/%s/%s' % (sport, league, ep)
+                url = 'https://api.stattleship.com/%s/%s/%s' % (sport, league, ep)
                 
-                if page >= 1 and isinstance(page, Number):
+                if page >= 1 and isinstance(page, int):
                         param['page'] = page
                 
                 headers = {
-                        'Authorization': token,
+                        'Authorization': 'Token token=%s' %token,
                         'Accept':'application/vnd.stattleship.com; version=%s' %version,
                         'Content-Type':'application/json'        
                 }
@@ -81,7 +81,7 @@ class Stattleship(object):
                 print(res)
                 print(res.url)
                 
-                content = json.loads(res.content)
+                content = res.json()
                 
                 return(content)
         

--- a/stattlepy/__init__.py
+++ b/stattlepy/__init__.py
@@ -1,2 +1,2 @@
 ### Import Statteleship class upon initiation of the program
-from Stattleship_API import Stattleship
+from .Stattleship_API import Stattleship


### PR DESCRIPTION
Hiya, 

I had a few issues in Python 3.5.1 getting the SDK working, and these fixes did the trick.

- if `page` was `None`, it'd crash out on line 70. `Number` was also not a defined object.
- Corrected `www` to `api` -- I see this was done in another PR for Python 2.
- Corrected the `Authorization` header format.
- This might be the most controversial; I changed `__init__.py` to be a local reference. This worked for me using `sudo python setup.py install`, but I'm not sure if pip will crash out. *Please* test this in all supported ways to install this SDK before you merge! I can do too, if you can enumerate them. 

Thanks! LMK if this is the wrong branch.